### PR TITLE
Split domain code into small packages

### DIFF
--- a/internal/chat/domain/message/entity.go
+++ b/internal/chat/domain/message/entity.go
@@ -1,0 +1,52 @@
+package message
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/user"
+
+	"github.com/vdrpkv/goexamples/internal/pkg/entity"
+)
+
+type (
+	Entity struct {
+		entity.Entity
+
+		ID     ID
+		UserID user.ID
+		RoomID room.ID
+
+		Text string
+	}
+
+	ID string
+)
+
+var (
+	ErrEmptyID = errors.New("id is empty")
+)
+
+func (id ID) Validate() error {
+	if id == "" {
+		return ErrEmptyID
+	}
+	return nil
+}
+
+func (m Entity) Validate() error {
+	if err := m.ID.Validate(); err != nil {
+		return fmt.Errorf("id: %w", err)
+	}
+
+	if err := m.UserID.Validate(); err != nil {
+		return fmt.Errorf("user id: %w", err)
+	}
+
+	if err := m.RoomID.Validate(); err != nil {
+		return fmt.Errorf("room id: %w", err)
+	}
+
+	return nil
+}

--- a/internal/chat/domain/message/usecase/receive/usecase/gateway.go
+++ b/internal/chat/domain/message/usecase/receive/usecase/gateway.go
@@ -1,0 +1,16 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/message"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/session"
+)
+
+type GatewaySessionMessageDeliverer interface {
+	GatewayDeliverMessageToSession(
+		ctx context.Context,
+		sessionID session.ID,
+		message *message.Entity,
+	) error
+}

--- a/internal/chat/domain/message/usecase/receive/usecase/usecase.go
+++ b/internal/chat/domain/message/usecase/receive/usecase/usecase.go
@@ -1,0 +1,51 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/message/usecase/receive"
+)
+
+type UseCase interface {
+	Do(
+		ctx context.Context,
+		args *receive.Args,
+	) (
+		*receive.Result,
+		error,
+	)
+}
+
+func New(
+	gatewaySessionMessageDeliverer GatewaySessionMessageDeliverer,
+) UseCase {
+	return useCase{
+		gatewaySessionMessageDeliverer: gatewaySessionMessageDeliverer,
+	}
+}
+
+type useCase struct {
+	gatewaySessionMessageDeliverer GatewaySessionMessageDeliverer
+}
+
+func (uc useCase) Do(
+	ctx context.Context,
+	args *receive.Args,
+) (
+	*receive.Result,
+	error,
+) {
+	err := uc.
+		gatewaySessionMessageDeliverer.
+		GatewayDeliverMessageToSession(
+			ctx,
+			args.SessionID,
+			args.Message,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("deliver message to session: %w", err)
+	}
+
+	return &receive.Result{}, nil
+}

--- a/internal/chat/domain/message/usecase/receive/validator/gateway.go
+++ b/internal/chat/domain/message/usecase/receive/validator/gateway.go
@@ -1,0 +1,16 @@
+package validator
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/session"
+)
+
+type GatewaySessionFinder interface {
+	GatewayFindSession(
+		ctx context.Context, sessionID session.ID,
+	) (
+		*session.Entity,
+		error,
+	)
+}

--- a/internal/chat/domain/message/usecase/receive/validator/validator.go
+++ b/internal/chat/domain/message/usecase/receive/validator/validator.go
@@ -1,0 +1,56 @@
+package validator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/message/usecase/receive"
+)
+
+type ArgsValidator interface {
+	ValidateArgs(ctx context.Context, args *receive.Args) error
+}
+
+var (
+	ErrNotFoundSession = errors.New("session is not found")
+)
+
+func New(
+	gatewaySessionFinder GatewaySessionFinder,
+) ArgsValidator {
+	return argsValidator{
+		gatewaySessionFinder: gatewaySessionFinder,
+	}
+}
+
+type argsValidator struct {
+	gatewaySessionFinder GatewaySessionFinder
+}
+
+func (v argsValidator) ValidateArgs(
+	ctx context.Context, args *receive.Args,
+) error {
+	if err := args.SessionID.Validate(); err != nil {
+		return fmt.Errorf("session id: %w", err)
+	}
+
+	if err := args.Message.Validate(); err != nil {
+		return fmt.Errorf("message: %w", err)
+	}
+
+	sessionEntity, err := v.
+		gatewaySessionFinder.
+		GatewayFindSession(
+			ctx, args.SessionID,
+		)
+	if err != nil {
+		return fmt.Errorf("find session: %w", err)
+	}
+
+	if sessionEntity == nil {
+		return ErrNotFoundSession
+	}
+
+	return nil
+}

--- a/internal/chat/domain/message/usecase/receive/values.go
+++ b/internal/chat/domain/message/usecase/receive/values.go
@@ -1,0 +1,14 @@
+package receive
+
+import (
+	"github.com/vdrpkv/goexamples/internal/chat/domain/message"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/session"
+)
+
+type Args struct {
+	SessionID session.ID
+	Message   *message.Entity
+}
+
+type Result struct {
+}

--- a/internal/chat/domain/message/usecase/send/usecase/gateway.go
+++ b/internal/chat/domain/message/usecase/send/usecase/gateway.go
@@ -1,0 +1,28 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/message"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/user"
+)
+
+type GatewayMessageCreator interface {
+	GatewayCreateMessage(
+		ctx context.Context,
+		authorUserID user.ID,
+		roomID room.ID,
+		messageText string,
+	) (
+		*message.Entity,
+		error,
+	)
+}
+
+type GatewayNewMessageSessionsNotifier interface {
+	GatewayNotifySessionsAboutNewMessage(
+		ctx context.Context,
+		nessage *message.Entity,
+	) error
+}

--- a/internal/chat/domain/message/usecase/send/usecase/usecase.go
+++ b/internal/chat/domain/message/usecase/send/usecase/usecase.go
@@ -1,0 +1,58 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/message/usecase/send"
+)
+
+type UseCase interface {
+	Do(ctx context.Context, args *send.Args) (*send.Result, error)
+}
+
+func New(
+	gatewayMessageCreator GatewayMessageCreator,
+	gatewayNewMessageSessionsNotifier GatewayNewMessageSessionsNotifier,
+) UseCase {
+	return useCase{
+		gatewayMessageCreator:             gatewayMessageCreator,
+		gatewayNewMessageSessionsNotifier: gatewayNewMessageSessionsNotifier,
+	}
+}
+
+type useCase struct {
+	gatewayMessageCreator             GatewayMessageCreator
+	gatewayNewMessageSessionsNotifier GatewayNewMessageSessionsNotifier
+}
+
+func (uc useCase) Do(
+	ctx context.Context,
+	args *send.Args,
+) (
+	*send.Result,
+	error,
+) {
+	messageEntity, err := uc.
+		gatewayMessageCreator.
+		GatewayCreateMessage(
+			ctx,
+			args.AuthorUserID,
+			args.RoomID,
+			args.MessageText,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("create message: %w", err)
+	}
+
+	err = uc.
+		gatewayNewMessageSessionsNotifier.
+		GatewayNotifySessionsAboutNewMessage(
+			ctx, messageEntity,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("notify sessions about new message: %w", err)
+	}
+
+	return &send.Result{}, nil
+}

--- a/internal/chat/domain/message/usecase/send/validator/gateway.go
+++ b/internal/chat/domain/message/usecase/send/validator/gateway.go
@@ -1,0 +1,16 @@
+package validator
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/user"
+)
+
+type GatewayUserFinder interface {
+	GatewayFindUser(ctx context.Context, userID user.ID) (*user.Entity, error)
+}
+
+type GatewayRoomFinder interface {
+	GatewayRoomFinder(ctx context.Context, roomID room.ID) (*room.Entity, error)
+}

--- a/internal/chat/domain/message/usecase/send/validator/validator.go
+++ b/internal/chat/domain/message/usecase/send/validator/validator.go
@@ -1,0 +1,73 @@
+package validator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/message/usecase/send"
+)
+
+var (
+	ErrNotFoundAuthorUser = errors.New("author user is not found")
+	ErrNotFoundRoom       = errors.New("room is not found")
+)
+
+type ArgsValidator interface {
+	ValidateArgs(ctx context.Context, args *send.Args) error
+}
+
+func New(
+	gatewayUserFinder GatewayUserFinder,
+	gatewayRoomFinder GatewayRoomFinder,
+) ArgsValidator {
+	return argsValidator{
+		gatewayUserFinder: gatewayUserFinder,
+		gatewayRoomFinder: gatewayRoomFinder,
+	}
+}
+
+type argsValidator struct {
+	gatewayUserFinder GatewayUserFinder
+	gatewayRoomFinder GatewayRoomFinder
+}
+
+func (v argsValidator) ValidateArgs(
+	ctx context.Context, args *send.Args,
+) error {
+	if err := args.AuthorUserID.Validate(); err != nil {
+		return fmt.Errorf("author user id: %w", err)
+	}
+
+	if err := args.RoomID.Validate(); err != nil {
+		return fmt.Errorf("room id: %w", err)
+	}
+
+	authorUserEntity, err := v.
+		gatewayUserFinder.
+		GatewayFindUser(
+			ctx, args.AuthorUserID,
+		)
+	if err != nil {
+		return fmt.Errorf("find author user: %w", err)
+	}
+
+	if authorUserEntity == nil {
+		return ErrNotFoundAuthorUser
+	}
+
+	roomEntity, err := v.
+		gatewayRoomFinder.
+		GatewayRoomFinder(
+			ctx, args.RoomID,
+		)
+	if err != nil {
+		return fmt.Errorf("find room: %w", err)
+	}
+
+	if roomEntity == nil {
+		return ErrNotFoundRoom
+	}
+
+	return nil
+}

--- a/internal/chat/domain/message/usecase/send/values.go
+++ b/internal/chat/domain/message/usecase/send/values.go
@@ -1,0 +1,15 @@
+package send
+
+import (
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/user"
+)
+
+type Args struct {
+	AuthorUserID user.ID
+	RoomID       room.ID
+	MessageText  string
+}
+
+type Result struct {
+}

--- a/internal/chat/domain/room/entity.go
+++ b/internal/chat/domain/room/entity.go
@@ -1,0 +1,41 @@
+package room
+
+import (
+	"errors"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/user"
+	"github.com/vdrpkv/goexamples/internal/pkg/entity"
+)
+
+type (
+	Entity struct {
+		entity.Entity
+
+		ID     ID
+		UserID user.ID
+
+		Name string
+	}
+
+	ID   string
+	Name string
+)
+
+var (
+	ErrEmptyID   = errors.New("id is empty")
+	ErrEmptyName = errors.New("name is empty")
+)
+
+func (id ID) Validate() error {
+	if id == "" {
+		return ErrEmptyID
+	}
+	return nil
+}
+
+func (n Name) Validate() error {
+	if n == "" {
+		return ErrEmptyName
+	}
+	return nil
+}

--- a/internal/chat/domain/room/usecase/create/usecase/gateway.go
+++ b/internal/chat/domain/room/usecase/create/usecase/gateway.go
@@ -1,0 +1,26 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/user"
+)
+
+type GatewayRoomCreator interface {
+	GatewayCreateRoom(
+		ctx context.Context,
+		creatorUserID user.ID,
+		roomName room.Name,
+	) (
+		*room.Entity,
+		error,
+	)
+}
+
+type GatewayNewRoomSessionsNotifier interface {
+	GatewayNotifySessionsAboutNewRoom(
+		ctx context.Context,
+		room *room.Entity,
+	) error
+}

--- a/internal/chat/domain/room/usecase/create/usecase/usecase.go
+++ b/internal/chat/domain/room/usecase/create/usecase/usecase.go
@@ -1,0 +1,63 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room/usecase/create"
+)
+
+type UseCase interface {
+	Do(
+		ctx context.Context,
+		args *create.Args,
+	) (
+		*create.Result,
+		error,
+	)
+}
+
+func New(
+	gatewayRoomCreator GatewayRoomCreator,
+	gatewayNewRoomSessionsNotifier GatewayNewRoomSessionsNotifier,
+) UseCase {
+	return useCase{
+		gatewayRoomCreator:             gatewayRoomCreator,
+		gatewayNewRoomSessionsNotifier: gatewayNewRoomSessionsNotifier,
+	}
+}
+
+type useCase struct {
+	gatewayRoomCreator             GatewayRoomCreator
+	gatewayNewRoomSessionsNotifier GatewayNewRoomSessionsNotifier
+}
+
+func (uc useCase) Do(
+	ctx context.Context,
+	args *create.Args,
+) (
+	*create.Result,
+	error,
+) {
+	roomEntity, err := uc.
+		gatewayRoomCreator.
+		GatewayCreateRoom(
+			ctx, args.CreatorUserID, args.RoomName,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("create room: %w", err)
+	}
+
+	err = uc.
+		gatewayNewRoomSessionsNotifier.
+		GatewayNotifySessionsAboutNewRoom(
+			ctx, roomEntity,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("notify sessions about new room: %w", err)
+	}
+
+	return &create.Result{
+		Room: roomEntity,
+	}, nil
+}

--- a/internal/chat/domain/room/usecase/create/validator/gateway.go
+++ b/internal/chat/domain/room/usecase/create/validator/gateway.go
@@ -1,0 +1,28 @@
+package validator
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/user"
+)
+
+type GatewayUserFinder interface {
+	GatewayFindUser(
+		ctx context.Context,
+		userID user.ID,
+	) (
+		*user.Entity,
+		error,
+	)
+}
+
+type GatewayRoomFinder interface {
+	GatewayFindRoom(
+		ctx context.Context,
+		roomName room.Name,
+	) (
+		*room.Entity,
+		error,
+	)
+}

--- a/internal/chat/domain/room/usecase/create/validator/validator.go
+++ b/internal/chat/domain/room/usecase/create/validator/validator.go
@@ -1,0 +1,73 @@
+package validator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room/usecase/create"
+)
+
+type ArgsValidator interface {
+	ValidateArgs(ctx context.Context, args *create.Args) error
+}
+
+var (
+	ErrNotFoundCreatorUser = errors.New("creator user is not found")
+	ErrNotUniqueRoomName   = errors.New("room name is not unique")
+)
+
+func NewUseCaseRoomCreateArgsValidator(
+	gatewayUserFinder GatewayUserFinder,
+	gatewayRoomFinder GatewayRoomFinder,
+) ArgsValidator {
+	return argsValidator{
+		gatewayUserFinder: gatewayUserFinder,
+		gatewayRoomFinder: gatewayRoomFinder,
+	}
+}
+
+type argsValidator struct {
+	gatewayUserFinder GatewayUserFinder
+	gatewayRoomFinder GatewayRoomFinder
+}
+
+func (v argsValidator) ValidateArgs(
+	ctx context.Context, args *create.Args,
+) error {
+	if err := args.CreatorUserID.Validate(); err != nil {
+		return fmt.Errorf("creator user id: %w", err)
+	}
+
+	if err := args.RoomName.Validate(); err != nil {
+		return fmt.Errorf("room name: %w", err)
+	}
+
+	creatorUserEntity, err := v.
+		gatewayUserFinder.
+		GatewayFindUser(
+			ctx, args.CreatorUserID,
+		)
+	if err != nil {
+		return fmt.Errorf("find creator user: %w", err)
+	}
+
+	if creatorUserEntity == nil {
+		return ErrNotFoundCreatorUser
+	}
+
+	roomEntity, err := v.
+		gatewayRoomFinder.
+		GatewayFindRoom(
+			ctx, args.RoomName,
+		)
+	if err != nil {
+		return fmt.Errorf("find room: %w", err)
+	}
+
+	if roomEntity != nil {
+		return ErrNotUniqueRoomName
+	}
+
+	return nil
+}

--- a/internal/chat/domain/room/usecase/create/values.go
+++ b/internal/chat/domain/room/usecase/create/values.go
@@ -1,0 +1,15 @@
+package create
+
+import (
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/user"
+)
+
+type Args struct {
+	CreatorUserID user.ID
+	RoomName      room.Name
+}
+
+type Result struct {
+	Room *room.Entity
+}

--- a/internal/chat/domain/room/usecase/delete/usecase/gateway.go
+++ b/internal/chat/domain/room/usecase/delete/usecase/gateway.go
@@ -1,0 +1,25 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+)
+
+type GatewaySessionsRoomMessagesUnsubscriber interface {
+	GatewayUnsubscribeSessionsFromRoomMessages(
+		ctx context.Context, roomID room.ID,
+	) error
+}
+
+type GatewayRoomDeleter interface {
+	GatewayDeleteRoom(
+		ctx context.Context, roomID room.ID,
+	) error
+}
+
+type GatewaySessionsRoomRemovalNotifier interface {
+	GatewayNotifySessionsAboutRemovedRoom(
+		ctx context.Context, roomID room.ID,
+	) error
+}

--- a/internal/chat/domain/room/usecase/delete/usecase/usecase.go
+++ b/internal/chat/domain/room/usecase/delete/usecase/usecase.go
@@ -1,0 +1,73 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room/usecase/delete"
+)
+
+type UseCase interface {
+	Do(
+		ctx context.Context,
+		args *delete.Args,
+	) (
+		*delete.Result,
+		error,
+	)
+}
+
+func New(
+	gatewaySessionsRoomMessagesUnsubscriber GatewaySessionsRoomMessagesUnsubscriber,
+	gatewayRoomDeleter GatewayRoomDeleter,
+	gatewaySessionsRoomRemovalNotifier GatewaySessionsRoomRemovalNotifier,
+) UseCase {
+	return useCaseRoomDelete{
+		gatewaySessionsRoomMessagesUnsubscriber: gatewaySessionsRoomMessagesUnsubscriber,
+		gatewayRoomDeleter:                      gatewayRoomDeleter,
+		gatewaySessionsRoomRemovalNotifier:      gatewaySessionsRoomRemovalNotifier,
+	}
+}
+
+type useCaseRoomDelete struct {
+	gatewaySessionsRoomMessagesUnsubscriber GatewaySessionsRoomMessagesUnsubscriber
+	gatewayRoomDeleter                      GatewayRoomDeleter
+	gatewaySessionsRoomRemovalNotifier      GatewaySessionsRoomRemovalNotifier
+}
+
+func (uc useCaseRoomDelete) Do(
+	ctx context.Context,
+	args *delete.Args,
+) (
+	*delete.Result,
+	error,
+) {
+	err := uc.
+		gatewaySessionsRoomMessagesUnsubscriber.
+		GatewayUnsubscribeSessionsFromRoomMessages(
+			ctx, args.RoomID,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("unsubsribe sessions from room messages: %w", err)
+	}
+
+	err = uc.
+		gatewayRoomDeleter.
+		GatewayDeleteRoom(
+			ctx, args.RoomID,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("delete room: %w", err)
+	}
+
+	err = uc.
+		gatewaySessionsRoomRemovalNotifier.
+		GatewayNotifySessionsAboutRemovedRoom(
+			ctx, args.RoomID,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("notify sessions about removed room: %w", err)
+	}
+
+	return nil, nil
+}

--- a/internal/chat/domain/room/usecase/delete/validator/gateway.go
+++ b/internal/chat/domain/room/usecase/delete/validator/gateway.go
@@ -1,0 +1,16 @@
+package validator
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+)
+
+type GatewayRoomFinder interface {
+	GatewayFindRoom(
+		ctx context.Context, roomID room.ID,
+	) (
+		*room.Entity,
+		error,
+	)
+}

--- a/internal/chat/domain/room/usecase/delete/validator/validator.go
+++ b/internal/chat/domain/room/usecase/delete/validator/validator.go
@@ -1,0 +1,52 @@
+package validator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room/usecase/delete"
+)
+
+type ArgsValidator interface {
+	ValidateArgs(ctx context.Context, args *delete.Args) error
+}
+
+var (
+	ErrNotFoundRoom = errors.New("room is not found")
+)
+
+func New(
+	gatewayRoomFinder GatewayRoomFinder,
+) ArgsValidator {
+	return argsValidator{
+		gatewayRoomFinder: gatewayRoomFinder,
+	}
+}
+
+type argsValidator struct {
+	gatewayRoomFinder GatewayRoomFinder
+}
+
+func (v argsValidator) ValidateArgs(
+	ctx context.Context, args *delete.Args,
+) error {
+	if err := args.RoomID.Validate(); err != nil {
+		return fmt.Errorf("room id: %w", err)
+	}
+
+	roomEntity, err := v.
+		gatewayRoomFinder.
+		GatewayFindRoom(
+			ctx, args.RoomID,
+		)
+	if err != nil {
+		return fmt.Errorf("find room: %w", err)
+	}
+
+	if roomEntity != nil {
+		return ErrNotFoundRoom
+	}
+
+	return nil
+}

--- a/internal/chat/domain/room/usecase/delete/values.go
+++ b/internal/chat/domain/room/usecase/delete/values.go
@@ -1,0 +1,10 @@
+package delete
+
+import "github.com/vdrpkv/goexamples/internal/chat/domain/room"
+
+type Args struct {
+	RoomID room.ID
+}
+
+type Result struct {
+}

--- a/internal/chat/domain/room/usecase/enter/usecase/gateway.go
+++ b/internal/chat/domain/room/usecase/enter/usecase/gateway.go
@@ -1,0 +1,16 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/session"
+)
+
+type GatewaySessionRoomMessagesSubscriber interface {
+	GatewaySubscribeSessionForRoomMessages(
+		ctx context.Context,
+		sessionID session.ID,
+		roomID room.ID,
+	) error
+}

--- a/internal/chat/domain/room/usecase/enter/usecase/usecase.go
+++ b/internal/chat/domain/room/usecase/enter/usecase/usecase.go
@@ -1,0 +1,49 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room/usecase/enter"
+)
+
+type UseCase interface {
+	Do(
+		ctx context.Context,
+		args *enter.Args,
+	) (
+		*enter.Result,
+		error,
+	)
+}
+
+func New(
+	gatewaySessionRoomMessagesSubscriber GatewaySessionRoomMessagesSubscriber,
+) UseCase {
+	return useCase{
+		gatewaySessionRoomMessagesSubscriber: gatewaySessionRoomMessagesSubscriber,
+	}
+}
+
+type useCase struct {
+	gatewaySessionRoomMessagesSubscriber GatewaySessionRoomMessagesSubscriber
+}
+
+func (uc useCase) Do(
+	ctx context.Context,
+	args *enter.Args,
+) (
+	*enter.Result,
+	error,
+) {
+	err := uc.
+		gatewaySessionRoomMessagesSubscriber.
+		GatewaySubscribeSessionForRoomMessages(
+			ctx, args.SessionID, args.RoomID,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("subscribe session for room messages: %w", err)
+	}
+
+	return &enter.Result{}, nil
+}

--- a/internal/chat/domain/room/usecase/enter/validator/gateway.go
+++ b/internal/chat/domain/room/usecase/enter/validator/gateway.go
@@ -1,0 +1,26 @@
+package validator
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/session"
+)
+
+type GatewaySessionFinder interface {
+	GatewayFindSession(
+		ctx context.Context, sessionID session.ID,
+	) (
+		*session.Entity,
+		error,
+	)
+}
+
+type GatewayRoomFinder interface {
+	GatewayFindRoom(
+		ctx context.Context, roomID room.ID,
+	) (
+		*room.Entity,
+		error,
+	)
+}

--- a/internal/chat/domain/room/usecase/enter/validator/validator.go
+++ b/internal/chat/domain/room/usecase/enter/validator/validator.go
@@ -1,0 +1,73 @@
+package validator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room/usecase/enter"
+)
+
+type ArgsValidator interface {
+	ValidateArgs(ctx context.Context, args *enter.Args) error
+}
+
+var (
+	ErrNotFoundSession = errors.New("session is not found")
+	ErrNotFoundRoom    = errors.New("room is not found")
+)
+
+func New(
+	gatewaySessionFinder GatewaySessionFinder,
+	gatewayRoomFinder GatewayRoomFinder,
+) ArgsValidator {
+	return argsValidator{
+		gatewaySessionFinder: gatewaySessionFinder,
+		gatewayRoomFinder:    gatewayRoomFinder,
+	}
+}
+
+type argsValidator struct {
+	gatewaySessionFinder GatewaySessionFinder
+	gatewayRoomFinder    GatewayRoomFinder
+}
+
+func (v argsValidator) ValidateArgs(
+	ctx context.Context, args *enter.Args,
+) error {
+	if err := args.SessionID.Validate(); err != nil {
+		return fmt.Errorf("session id: %w", err)
+	}
+
+	if err := args.RoomID.Validate(); err != nil {
+		return fmt.Errorf("room id: %w", err)
+	}
+
+	sessionEntity, err := v.
+		gatewaySessionFinder.
+		GatewayFindSession(
+			ctx, args.SessionID,
+		)
+	if err != nil {
+		return fmt.Errorf("find session: %w", err)
+	}
+
+	if sessionEntity == nil {
+		return ErrNotFoundSession
+	}
+
+	roomEntity, err := v.
+		gatewayRoomFinder.
+		GatewayFindRoom(
+			ctx, args.RoomID,
+		)
+	if err != nil {
+		return fmt.Errorf("find room: %w", err)
+	}
+
+	if roomEntity == nil {
+		return ErrNotFoundRoom
+	}
+
+	return nil
+}

--- a/internal/chat/domain/room/usecase/enter/values.go
+++ b/internal/chat/domain/room/usecase/enter/values.go
@@ -1,0 +1,14 @@
+package enter
+
+import (
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/session"
+)
+
+type Args struct {
+	SessionID session.ID
+	RoomID    room.ID
+}
+
+type Result struct {
+}

--- a/internal/chat/domain/room/usecase/exit/usecase/gateway.go
+++ b/internal/chat/domain/room/usecase/exit/usecase/gateway.go
@@ -1,0 +1,16 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/session"
+)
+
+type GatewaySessionRoomMessagesUnsubscriber interface {
+	GatewayUnsubscribeSessionForRoomMessages(
+		ctx context.Context,
+		sessionID session.ID,
+		roomID room.ID,
+	) error
+}

--- a/internal/chat/domain/room/usecase/exit/usecase/usecase.go
+++ b/internal/chat/domain/room/usecase/exit/usecase/usecase.go
@@ -1,0 +1,49 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room/usecase/exit"
+)
+
+type UseCase interface {
+	Do(
+		ctx context.Context,
+		args *exit.Args,
+	) (
+		*exit.Result,
+		error,
+	)
+}
+
+func New(
+	gatewaySessionRoomMessagesUnsubscriber GatewaySessionRoomMessagesUnsubscriber,
+) UseCase {
+	return useCase{
+		gatewaySessionRoomMessagesUnsubscriber: gatewaySessionRoomMessagesUnsubscriber,
+	}
+}
+
+type useCase struct {
+	gatewaySessionRoomMessagesUnsubscriber GatewaySessionRoomMessagesUnsubscriber
+}
+
+func (uc useCase) Do(
+	ctx context.Context,
+	args *exit.Args,
+) (
+	*exit.Result,
+	error,
+) {
+	err := uc.
+		gatewaySessionRoomMessagesUnsubscriber.
+		GatewayUnsubscribeSessionForRoomMessages(
+			ctx, args.SessionID, args.RoomID,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("unsubscribe session for room messages: %w", err)
+	}
+
+	return &exit.Result{}, nil
+}

--- a/internal/chat/domain/room/usecase/exit/validator/gateway.go
+++ b/internal/chat/domain/room/usecase/exit/validator/gateway.go
@@ -1,0 +1,26 @@
+package validator
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/session"
+)
+
+type GatewaySessionFinder interface {
+	GatewayFindSession(
+		ctx context.Context, sessionID session.ID,
+	) (
+		*session.Entity,
+		error,
+	)
+}
+
+type GatewayRoomFinder interface {
+	GatewayFindRoom(
+		ctx context.Context, roomID room.ID,
+	) (
+		*room.Entity,
+		error,
+	)
+}

--- a/internal/chat/domain/room/usecase/exit/validator/validator.go
+++ b/internal/chat/domain/room/usecase/exit/validator/validator.go
@@ -1,0 +1,73 @@
+package validator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room/usecase/exit"
+)
+
+type ArgsValidator interface {
+	ValidateArgs(ctx context.Context, args *exit.Args) error
+}
+
+var (
+	ErrNotFoundSession = errors.New("session is not found")
+	ErrNotFoundRoom    = errors.New("room is not found")
+)
+
+func New(
+	gatewaySessionFinder GatewaySessionFinder,
+	gatewayRoomFinder GatewayRoomFinder,
+) ArgsValidator {
+	return argsValidator{
+		gatewaySessionFinder: gatewaySessionFinder,
+		gatewayRoomFinder:    gatewayRoomFinder,
+	}
+}
+
+type argsValidator struct {
+	gatewaySessionFinder GatewaySessionFinder
+	gatewayRoomFinder    GatewayRoomFinder
+}
+
+func (v argsValidator) ValidateArgs(
+	ctx context.Context, args *exit.Args,
+) error {
+	if err := args.SessionID.Validate(); err != nil {
+		return fmt.Errorf("session id: %w", err)
+	}
+
+	if err := args.RoomID.Validate(); err != nil {
+		return fmt.Errorf("room id: %w", err)
+	}
+
+	sessionEntity, err := v.
+		gatewaySessionFinder.
+		GatewayFindSession(
+			ctx, args.SessionID,
+		)
+	if err != nil {
+		return fmt.Errorf("find session: %w", err)
+	}
+
+	if sessionEntity == nil {
+		return ErrNotFoundSession
+	}
+
+	roomEntity, err := v.
+		gatewayRoomFinder.
+		GatewayFindRoom(
+			ctx, args.RoomID,
+		)
+	if err != nil {
+		return fmt.Errorf("find room: %w", err)
+	}
+
+	if roomEntity == nil {
+		return ErrNotFoundRoom
+	}
+
+	return nil
+}

--- a/internal/chat/domain/room/usecase/exit/values.go
+++ b/internal/chat/domain/room/usecase/exit/values.go
@@ -1,0 +1,14 @@
+package exit
+
+import (
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/session"
+)
+
+type Args struct {
+	SessionID session.ID
+	RoomID    room.ID
+}
+
+type Result struct {
+}

--- a/internal/chat/domain/room/usecase/list/usecase/gateway.go
+++ b/internal/chat/domain/room/usecase/list/usecase/gateway.go
@@ -1,0 +1,16 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room"
+)
+
+type GatewayRoomGetter interface {
+	GatewayGetAllRooms(
+		ctx context.Context,
+	) (
+		[]room.Entity,
+		error,
+	)
+}

--- a/internal/chat/domain/room/usecase/list/usecase/usecase.go
+++ b/internal/chat/domain/room/usecase/list/usecase/usecase.go
@@ -1,0 +1,51 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room/usecase/list"
+)
+
+type UseCase interface {
+	Do(
+		ctx context.Context,
+		args *list.Args,
+	) (
+		*list.Result,
+		error,
+	)
+}
+
+func New(
+	gatewayRoomGetter GatewayRoomGetter,
+) UseCase {
+	return useCase{
+		gatewayRoomGetter: gatewayRoomGetter,
+	}
+}
+
+type useCase struct {
+	gatewayRoomGetter GatewayRoomGetter
+}
+
+func (uc useCase) Do(
+	ctx context.Context,
+	args *list.Args,
+) (
+	*list.Result,
+	error,
+) {
+	roomEntities, err := uc.
+		gatewayRoomGetter.
+		GatewayGetAllRooms(
+			ctx,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("get all rooms: %w", err)
+	}
+
+	return &list.Result{
+		Rooms: roomEntities,
+	}, nil
+}

--- a/internal/chat/domain/room/usecase/list/validator/validator.go
+++ b/internal/chat/domain/room/usecase/list/validator/validator.go
@@ -1,0 +1,24 @@
+package validator
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/room/usecase/list"
+)
+
+type ArgsValidator interface {
+	ValidateArgs(ctx context.Context, args *list.Args) error
+}
+
+func NewUseCaseRoomListArgsValidator() ArgsValidator {
+	return argsValidator{}
+}
+
+type argsValidator struct {
+}
+
+func (v argsValidator) ValidateArgs(
+	ctx context.Context, args *list.Args,
+) error {
+	return nil
+}

--- a/internal/chat/domain/room/usecase/list/values.go
+++ b/internal/chat/domain/room/usecase/list/values.go
@@ -1,0 +1,10 @@
+package list
+
+import "github.com/vdrpkv/goexamples/internal/chat/domain/room"
+
+type Args struct {
+}
+
+type Result struct {
+	Rooms []room.Entity
+}

--- a/internal/chat/domain/session/entity.go
+++ b/internal/chat/domain/session/entity.go
@@ -1,0 +1,30 @@
+package session
+
+import (
+	"errors"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/user"
+	"github.com/vdrpkv/goexamples/internal/pkg/entity"
+)
+
+type (
+	Entity struct {
+		entity.Entity
+
+		ID     ID
+		UserID user.ID
+	}
+
+	ID string
+)
+
+var (
+	ErrEmptyID = errors.New("id is empty")
+)
+
+func (id ID) Validate() error {
+	if id == "" {
+		return ErrEmptyID
+	}
+	return nil
+}

--- a/internal/chat/domain/user/entity.go
+++ b/internal/chat/domain/user/entity.go
@@ -1,0 +1,39 @@
+package user
+
+import (
+	"errors"
+
+	"github.com/vdrpkv/goexamples/internal/pkg/entity"
+)
+
+type (
+	Entity struct {
+		entity.Entity
+
+		ID ID
+
+		Name Name
+	}
+
+	ID   string
+	Name string
+)
+
+var (
+	ErrEmptyID   = errors.New("id is empty")
+	ErrEmptyName = errors.New("name is empty")
+)
+
+func (id ID) Validate() error {
+	if id == "" {
+		return ErrEmptyID
+	}
+	return nil
+}
+
+func (n Name) Validate() error {
+	if n == "" {
+		return ErrEmptyName
+	}
+	return nil
+}

--- a/internal/chat/domain/user/usecase/enter/usecase/gateway.go
+++ b/internal/chat/domain/user/usecase/enter/usecase/gateway.go
@@ -1,0 +1,16 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/session"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/user"
+)
+
+type GatewayUserCreatorFinder interface {
+	GatewayCreateOrFindUser(ctx context.Context, userName user.Name) (*user.Entity, error)
+}
+
+type GatewaySessionCreator interface {
+	GatewayCreateSession(ctx context.Context, userID user.ID) (*session.Entity, error)
+}

--- a/internal/chat/domain/user/usecase/enter/usecase/usecase.go
+++ b/internal/chat/domain/user/usecase/enter/usecase/usecase.go
@@ -1,0 +1,63 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/user/usecase/enter"
+)
+
+type UseCase interface {
+	Do(
+		ctx context.Context,
+		args *enter.Args,
+	) (
+		*enter.Result,
+		error,
+	)
+}
+
+func New(
+	gatewayUserCreatorFinder GatewayUserCreatorFinder,
+	gatewaySessionCreator GatewaySessionCreator,
+) UseCase {
+	return useCase{
+		gatewayUserCreatorFinder: gatewayUserCreatorFinder,
+		gatewaySessionCreator:    gatewaySessionCreator,
+	}
+}
+
+type useCase struct {
+	gatewayUserCreatorFinder GatewayUserCreatorFinder
+	gatewaySessionCreator    GatewaySessionCreator
+}
+
+func (uc useCase) Do(
+	ctx context.Context,
+	args *enter.Args,
+) (
+	*enter.Result,
+	error,
+) {
+	userEntity, err := uc.
+		gatewayUserCreatorFinder.
+		GatewayCreateOrFindUser(
+			ctx, args.UserName,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("create or find user [%s]: %w", args.UserName, err)
+	}
+
+	sessionEntity, err := uc.
+		gatewaySessionCreator.
+		GatewayCreateSession(
+			ctx, userEntity.ID,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("create session: %w", err)
+	}
+
+	return &enter.Result{
+		SessionID: sessionEntity.ID,
+	}, nil
+}

--- a/internal/chat/domain/user/usecase/enter/validator/validator.go
+++ b/internal/chat/domain/user/usecase/enter/validator/validator.go
@@ -1,0 +1,27 @@
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vdrpkv/goexamples/internal/chat/domain/user/usecase/enter"
+)
+
+type ArgsValidator interface {
+	ValidateArgs(ctx context.Context, args *enter.Args) error
+}
+
+func NewArgsValidator() ArgsValidator {
+	return argsValidator{}
+}
+
+type argsValidator struct{}
+
+func (v argsValidator) ValidateArgs(
+	ctx context.Context, args *enter.Args,
+) error {
+	if err := args.UserName.Validate(); err != nil {
+		return fmt.Errorf("user name: %w", err)
+	}
+	return nil
+}

--- a/internal/chat/domain/user/usecase/enter/values.go
+++ b/internal/chat/domain/user/usecase/enter/values.go
@@ -1,0 +1,14 @@
+package enter
+
+import (
+	"github.com/vdrpkv/goexamples/internal/chat/domain/session"
+	"github.com/vdrpkv/goexamples/internal/chat/domain/user"
+)
+
+type Args struct {
+	UserName user.Name
+}
+
+type Result struct {
+	SessionID session.ID
+}


### PR DESCRIPTION
This should simplify the code by making names shorter.

It implies coding overhead forcing developer to use import aliases in some cases.

It makes code simple to read and understand.